### PR TITLE
Collisions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,9 @@ These are a bunch of demo programs created to learn features of ggez or test con
 Use command `cargo run --example [example_name]` where `[example_name]` is one of the examples.
 
 ## List of Examples
+* `collisions`
+Example based on collision detection.
+Work in progress to develop the idea.
 * `display_user_text`  
 Loads a font type file to display text in custom font.  
 Accepts user text input, displaying to the screen.  

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,9 +7,10 @@ These are a bunch of demo programs created to learn features of ggez or test con
 Use command `cargo run --example [example_name]` where `[example_name]` is one of the examples.
 
 ## List of Examples
-* `collisions`
-Example based on collision detection.
-Work in progress to develop the idea.
+* `collisions`  
+Example of collision detection using trait.  
+Move square with arrow keys.  
+On collision a message will be printed to console.
 * `display_user_text`  
 Loads a font type file to display text in custom font.  
 Accepts user text input, displaying to the screen.  

--- a/examples/collisions.rs
+++ b/examples/collisions.rs
@@ -1,0 +1,123 @@
+use ggez::*;
+
+trait Entity: event::EventHandler {
+    // note: where self: Sized is needed for compiler to be able to make trait
+    // object when trait function does not have a self parameter
+    // https://doc.rust-lang.org/error-index.html#method-has-no-receiver
+    //fn new() -> Self where Self: Sized;
+
+    fn bounding_box(&self) -> graphics::Rect;
+
+    fn display_bounding_box(&self) -> bool {
+        false
+    }
+}
+
+struct Circle {
+    location: nalgebra::Point2<f32>,
+    radius: f32,
+}
+impl Circle {
+    fn new(x: f32, y:f32, r:f32) -> Circle {
+        Circle{
+            location: nalgebra::Point2::<f32>::new(x, y),
+            radius: r,
+        }
+    }
+}
+impl Entity for Circle {
+    /*
+    fn new() -> Self {
+        Circle{
+            location: nalgebra::Point2::<f32>::new(400.0, 300.0),
+            radius: 200.0,
+        }
+    }*/
+    
+    fn bounding_box(&self) -> graphics::Rect {
+        graphics::Rect::new(
+            self.location[0] - self.radius,
+            self.location[1] - self.radius,
+            self.radius * 2.0,
+            self.radius * 2.0
+        )
+    }
+}
+impl event::EventHandler for Circle {
+    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+        Ok(())
+    }
+    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+        let circle = graphics::Mesh::new_circle(
+            ctx,
+            graphics::DrawMode::fill(),
+            self.location,
+            self.radius,
+            5.0,
+            graphics::WHITE
+        )?;
+        graphics::draw(ctx, &circle, graphics::DrawParam::default())?;
+
+        let rectangle = graphics::Mesh::new_rectangle(
+            ctx, 
+            graphics::DrawMode::stroke(1.0),
+            self.bounding_box(),
+            graphics::WHITE
+        )?;
+        graphics::draw(ctx, &rectangle, graphics::DrawParam::default())?;
+
+        Ok(())
+    }
+}
+
+struct State {
+    entities: Vec<Box<Entity>>,
+}
+
+impl State {
+    fn new() -> State {
+        let mut v = Vec::<Box<Entity>>::new();
+        v.push(Box::new(Circle::new(20.0, 20.0, 20.0)));
+        v.push(Box::new(Circle::new(400.0, 300.0, 50.0)));
+        v.push(Box::new(Circle::new(100.0, 500.0, 100.0)));
+        State{ entities: v }
+    }
+}
+
+impl event::EventHandler for State {
+    // game loop to update logic... should do something...
+    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+        Ok(())
+    }
+
+    // draw things to screen
+    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+        // clear screen
+        graphics::clear(ctx, graphics::BLACK);
+
+        for i in &mut self.entities {
+            i.draw(ctx)?;
+        }        
+
+        // display to screen
+        graphics::present(ctx)?;
+        timer::yield_now();
+        Ok(())
+    }
+}
+
+fn main() {
+    // create context
+    let (ctx, event_loop) = &mut ContextBuilder::new("collisions", "people")
+        .window_setup(conf::WindowSetup::default().title("Collision Detection"))
+        .build()
+        .unwrap();
+    // create state and game loop
+    let state = &mut State::new();
+    // run loop
+    match event::run(ctx, event_loop, state) {
+        Ok(_) => println!("Clean loop exit"),
+        Err(e) => println!("Error loop exit {}", e),
+    };
+    println!("Goodbye!");
+}

--- a/examples/collisions.rs
+++ b/examples/collisions.rs
@@ -11,6 +11,12 @@ trait Entity: event::EventHandler {
     fn display_bounding_box(&self) -> bool {
         false
     }
+
+    fn collision(&self, e: &Entity) -> bool {
+        let us = &self.bounding_box();
+        let them = &e.bounding_box();
+        us.overlaps(them)
+    }
 }
 
 struct Circle {
@@ -25,15 +31,7 @@ impl Circle {
         }
     }
 }
-impl Entity for Circle {
-    /*
-    fn new() -> Self {
-        Circle{
-            location: nalgebra::Point2::<f32>::new(400.0, 300.0),
-            radius: 200.0,
-        }
-    }*/
-    
+impl Entity for Circle {    
     fn bounding_box(&self) -> graphics::Rect {
         graphics::Rect::new(
             self.location[0] - self.radius,
@@ -70,23 +68,74 @@ impl event::EventHandler for Circle {
     }
 }
 
-struct State {
-    entities: Vec<Box<Entity>>,
+
+
+struct Square {
+    location: nalgebra::Point2<f32>,
+    size: f32,
+}
+impl Square {
+    fn new(x: f32, y:f32, s:f32) -> Square {
+        Square{
+            location: nalgebra::Point2::<f32>::new(x, y),
+            size: s,
+        }
+    }
+}
+impl Entity for Square {    
+    fn bounding_box(&self) -> graphics::Rect {
+        graphics::Rect::new(
+            self.location[0] - self.size,
+            self.location[1] - self.size,
+            self.size,
+            self.size,
+        )
+    }
+}
+impl event::EventHandler for Square {
+    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+        Ok(())
+    }
+    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+        let rectangle = graphics::Mesh::new_rectangle(
+            ctx, 
+            graphics::DrawMode::fill(),
+            self.bounding_box(),
+            graphics::WHITE
+        )?;
+        graphics::draw(ctx, &rectangle, graphics::DrawParam::default())?;
+
+        Ok(())
+    }
 }
 
+struct State {
+    player: Box<Entity>,
+    entities: Vec<Box<Entity>>,
+}
 impl State {
     fn new() -> State {
         let mut v = Vec::<Box<Entity>>::new();
         v.push(Box::new(Circle::new(20.0, 20.0, 20.0)));
         v.push(Box::new(Circle::new(400.0, 300.0, 50.0)));
         v.push(Box::new(Circle::new(100.0, 500.0, 100.0)));
-        State{ entities: v }
+        v.push(Box::new(Square::new(500.0, 50.0, 20.0)));
+        v.push(Box::new(Square::new(700.0, 500.0, 100.0)));
+
+        let p = Box::new(Square::new(400.0, 60.0, 50.0));
+
+        State{ player: p, entities: v }
     }
 }
-
 impl event::EventHandler for State {
     // game loop to update logic... should do something...
     fn update(&mut self, _ctx: &mut Context) -> GameResult {
+        for i in &mut self.entities {
+            // get a reference to contents of box<Entity>
+            if i.collision(&*self.player) {
+                println!("Collision detected");
+            }
+        }
         Ok(())
     }
 
@@ -95,9 +144,11 @@ impl event::EventHandler for State {
         // clear screen
         graphics::clear(ctx, graphics::BLACK);
 
+        self.player.draw(ctx)?;
+
         for i in &mut self.entities {
             i.draw(ctx)?;
-        }        
+        }
 
         // display to screen
         graphics::present(ctx)?;

--- a/examples/collisions.rs
+++ b/examples/collisions.rs
@@ -26,20 +26,20 @@ struct Circle {
     radius: f32,
 }
 impl Circle {
-    fn new(x: f32, y:f32, r:f32) -> Circle {
-        Circle{
+    fn new(x: f32, y: f32, r: f32) -> Circle {
+        Circle {
             location: nalgebra::Point2::<f32>::new(x, y),
             radius: r,
         }
     }
 }
-impl Entity for Circle {    
+impl Entity for Circle {
     fn bounding_box(&self) -> graphics::Rect {
         graphics::Rect::new(
             self.location[0] - self.radius,
             self.location[1] - self.radius,
             self.radius * 2.0,
-            self.radius * 2.0
+            self.radius * 2.0,
         )
     }
 
@@ -60,15 +60,15 @@ impl event::EventHandler for Circle {
             self.location,
             self.radius,
             5.0,
-            graphics::WHITE
+            graphics::WHITE,
         )?;
         graphics::draw(ctx, &circle, graphics::DrawParam::default())?;
 
         let rectangle = graphics::Mesh::new_rectangle(
-            ctx, 
+            ctx,
             graphics::DrawMode::stroke(1.0),
             self.bounding_box(),
-            graphics::WHITE
+            graphics::WHITE,
         )?;
         graphics::draw(ctx, &rectangle, graphics::DrawParam::default())?;
 
@@ -76,21 +76,19 @@ impl event::EventHandler for Circle {
     }
 }
 
-
-
 struct Square {
     location: nalgebra::Point2<f32>,
     size: f32,
 }
 impl Square {
-    fn new(x: f32, y:f32, s:f32) -> Square {
-        Square{
+    fn new(x: f32, y: f32, s: f32) -> Square {
+        Square {
             location: nalgebra::Point2::<f32>::new(x, y),
             size: s,
         }
     }
 }
-impl Entity for Square {    
+impl Entity for Square {
     fn bounding_box(&self) -> graphics::Rect {
         graphics::Rect::new(
             self.location[0] - self.size,
@@ -112,10 +110,10 @@ impl event::EventHandler for Square {
     }
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
         let rectangle = graphics::Mesh::new_rectangle(
-            ctx, 
+            ctx,
             graphics::DrawMode::fill(),
             self.bounding_box(),
-            graphics::WHITE
+            graphics::WHITE,
         )?;
         graphics::draw(ctx, &rectangle, graphics::DrawParam::default())?;
 
@@ -138,7 +136,10 @@ impl State {
 
         let p = Box::new(Square::new(400.0, 60.0, 50.0));
 
-        State{ player: p, entities: v }
+        State {
+            player: p,
+            entities: v,
+        }
     }
 }
 impl event::EventHandler for State {

--- a/examples/collisions.rs
+++ b/examples/collisions.rs
@@ -17,6 +17,8 @@ trait Entity: event::EventHandler {
         let them = &e.bounding_box();
         us.overlaps(them)
     }
+
+    fn move_location(&mut self, x: f32, y: f32) -> nalgebra::Point2<f32>;
 }
 
 struct Circle {
@@ -39,6 +41,12 @@ impl Entity for Circle {
             self.radius * 2.0,
             self.radius * 2.0
         )
+    }
+
+    fn move_location(&mut self, x: f32, y: f32) -> nalgebra::Point2<f32> {
+        self.location[0] += x;
+        self.location[1] += y;
+        self.location
     }
 }
 impl event::EventHandler for Circle {
@@ -91,6 +99,12 @@ impl Entity for Square {
             self.size,
         )
     }
+
+    fn move_location(&mut self, x: f32, y: f32) -> nalgebra::Point2<f32> {
+        self.location[0] += x;
+        self.location[1] += y;
+        self.location
+    }
 }
 impl event::EventHandler for Square {
     fn update(&mut self, _ctx: &mut Context) -> GameResult {
@@ -129,7 +143,30 @@ impl State {
 }
 impl event::EventHandler for State {
     // game loop to update logic... should do something...
-    fn update(&mut self, _ctx: &mut Context) -> GameResult {
+    fn update(&mut self, ctx: &mut Context) -> GameResult {
+        // move player square
+        if input::keyboard::is_key_pressed(ctx, event::KeyCode::Right) {
+            if input::keyboard::is_mod_active(ctx, event::KeyMods::SHIFT) {
+                self.player.move_location(4.5, 0.0);
+            }
+            self.player.move_location(0.5, 0.0);
+        } else if input::keyboard::is_key_pressed(ctx, event::KeyCode::Left) {
+            if input::keyboard::is_mod_active(ctx, event::KeyMods::SHIFT) {
+                self.player.move_location(-4.5, 0.0);
+            }
+            self.player.move_location(-0.5, 0.0);
+        } else if input::keyboard::is_key_pressed(ctx, event::KeyCode::Up) {
+            if input::keyboard::is_mod_active(ctx, event::KeyMods::SHIFT) {
+                self.player.move_location(0.0, -4.5);
+            }
+            self.player.move_location(0.0, -0.5);
+        } else if input::keyboard::is_key_pressed(ctx, event::KeyCode::Down) {
+            if input::keyboard::is_mod_active(ctx, event::KeyMods::SHIFT) {
+                self.player.move_location(0.0, 4.5);
+            }
+            self.player.move_location(0.0, 0.5);
+        }
+
         for i in &mut self.entities {
             // get a reference to contents of box<Entity>
             if i.collision(&*self.player) {
@@ -144,11 +181,11 @@ impl event::EventHandler for State {
         // clear screen
         graphics::clear(ctx, graphics::BLACK);
 
-        self.player.draw(ctx)?;
-
         for i in &mut self.entities {
             i.draw(ctx)?;
         }
+
+        self.player.draw(ctx)?;
 
         // display to screen
         graphics::present(ctx)?;


### PR DESCRIPTION
I made a simple example of how a trait may be used to do collision detection.
All this does is check if player's hit box overlaps with another hit box.

Not a marked improvement over what main.rs does already...
Little bit of copy past code... could simplify it using generic type and an enum... maybe?